### PR TITLE
Remove Assignees

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -2,7 +2,7 @@
 addReviewers: true
 
 # Set to true to add assignees to pull requests
-addAssignees: true
+addAssignees: false
 
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:


### PR DESCRIPTION
#### Related Issues:
https://caravanning.atlassian.net/browse/CA-55

#### Description:
Right now, Autobot assigns two people as `reviewers` and two people as `assignees` the ticket randomly. This ticket is to stop it from assigning `assignees`.
