### PR TITLE
setting up user signup

### DIFF
--- a/src/components/InvitationDetails/InvitationDetails.scss
+++ b/src/components/InvitationDetails/InvitationDetails.scss
@@ -1,8 +1,0 @@
-@import '../../../src/utilities/colorPalette.scss';
-
-.invitation-details-wrapper {
-	color: white;
-	background: $dream-blue;
-	padding: 15px 25px;
-	border-radius: 30px;
-}

--- a/src/components/InvitationDetails/InvitationDetails.scss
+++ b/src/components/InvitationDetails/InvitationDetails.scss
@@ -1,0 +1,8 @@
+@import '../../../src/utilities/colorPalette.scss';
+
+.invitation-details-wrapper {
+	color: white;
+	background: $dream-blue;
+	padding: 15px 25px;
+	border-radius: 30px;
+}

--- a/src/components/Signup/Signup.jsx
+++ b/src/components/Signup/Signup.jsx
@@ -52,6 +52,7 @@ export const SignupForm = () => (
 			autoFocus={false}
 			component={Input}
 		/>
+		{/* To Do: error message when the email is already in the db */}
 		<Field
 			icon='email'
 			type='text'

--- a/src/components/Signup/Signup.jsx
+++ b/src/components/Signup/Signup.jsx
@@ -33,6 +33,7 @@ export const SignupForm = () => (
 			autoFocus={false}
 			component={Input}
 		/>
+		{/* TO DO: error message in case username already exists */}
 		<Field
 			icon='person_pin'
 			type='text'

--- a/src/components/Signup/Signup.jsx
+++ b/src/components/Signup/Signup.jsx
@@ -76,7 +76,7 @@ export const SignupForm = () => (
 	</Form>
 );
 
-const Signup = props => {
+export const Signup = props => {
 	return (
 		<div>
 			<Formik
@@ -90,9 +90,6 @@ const Signup = props => {
 				}}
 				onSubmit={values => {
 					const { history } = props;
-					// same shape as initial values
-					console.log(values);
-					console.log(props);
 					axios
 						.post('/signup', {
 							firstname: values.firstname,
@@ -103,7 +100,6 @@ const Signup = props => {
 							password: values.password,
 						})
 						.then(function(response) {
-							console.log(response);
 							history.push('/trip');
 						})
 						.catch(function(error) {

--- a/src/components/Signup/Signup.jsx
+++ b/src/components/Signup/Signup.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Field, Form, Formik } from 'formik';
+import { withRouter } from 'react-router';
+import axios from 'axios';
 
 import '../../utilities/fonts.scss';
 import Input from '../Input/Input';
@@ -16,7 +18,7 @@ export const SignupForm = () => (
 		<Field
 			icon='person_pin'
 			type='text'
-			name='first_name'
+			name='firstname'
 			placeholder='First Name'
 			validate={required}
 			autoFocus={true}
@@ -25,8 +27,17 @@ export const SignupForm = () => (
 		<Field
 			icon='person_pin'
 			type='text'
-			name='last_name'
+			name='lastname'
 			placeholder='Last Name'
+			validate={required}
+			autoFocus={false}
+			component={Input}
+		/>
+		<Field
+			icon='person_pin'
+			type='text'
+			name='username'
+			placeholder='Username'
 			validate={required}
 			autoFocus={false}
 			component={Input}
@@ -51,7 +62,7 @@ export const SignupForm = () => (
 		/>
 		<Field
 			icon='lock'
-			type='text'
+			type='password'
 			name='password'
 			placeholder='Password'
 			validate={validatePassword}
@@ -63,20 +74,39 @@ export const SignupForm = () => (
 	</Form>
 );
 
-const Signup = () => {
+const Signup = props => {
 	return (
 		<div>
 			<Formik
 				initialValues={{
-					first_name: '',
-					last_name: '',
+					firstname: '',
+					lastname: '',
+					username: '',
 					phone: '',
 					email: '',
 					password: '',
 				}}
 				onSubmit={values => {
+					const { history } = props;
 					// same shape as initial values
 					console.log(values);
+					console.log(props);
+					axios
+						.post('/signup', {
+							firstname: values.firstname,
+							lastname: values.lastname,
+							username: values.username,
+							email: values.email,
+							phonenumber: values.phone,
+							password: values.password,
+						})
+						.then(function(response) {
+							console.log(response);
+							history.push('/trip');
+						})
+						.catch(function(error) {
+							console.log(error);
+						});
 				}}
 			>
 				{() => <SignupForm />}
@@ -87,4 +117,4 @@ const Signup = () => {
 	);
 };
 
-export default Signup;
+export default withRouter(Signup);

--- a/src/components/Signup/Signup.test.jsx
+++ b/src/components/Signup/Signup.test.jsx
@@ -13,19 +13,25 @@ describe('SignupForm', () => {
 	it('should have five fields', () => {
 		const wrapper = shallow(<SignupForm />);
 		const fieldWrapper = wrapper.find('Field');
-		expect(fieldWrapper.length).toBe(5);
+		expect(fieldWrapper.length).toBe(6);
 	});
 	it('should have an first name field', () => {
 		const wrapper = shallow(<SignupForm />);
 		const fieldWrapper = wrapper.find('Field');
-		const firstNameField = fieldWrapper.find({ name: 'first_name' });
+		const firstNameField = fieldWrapper.find({ name: 'firstname' });
 		expect(firstNameField.length).toBe(1);
 	});
 	it('should have an last name field', () => {
 		const wrapper = shallow(<SignupForm />);
 		const fieldWrapper = wrapper.find('Field');
-		const lastNameField = fieldWrapper.find({ name: 'last_name' });
+		const lastNameField = fieldWrapper.find({ name: 'lastname' });
 		expect(lastNameField.length).toBe(1);
+	});
+	it('should have an username field', () => {
+		const wrapper = shallow(<SignupForm />);
+		const fieldWrapper = wrapper.find('Field');
+		const usernameField = fieldWrapper.find({ name: 'username' });
+		expect(usernameField.length).toBe(1);
 	});
 	it('should have an phone field', () => {
 		const wrapper = shallow(<SignupForm />);

--- a/src/components/Signup/Signup.test.jsx
+++ b/src/components/Signup/Signup.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import Signup, { SignupForm } from './Signup';
+import { SignupForm, Signup } from './Signup';
 
 describe('Signup', () => {
 	it('should match the snapshot', () => {

--- a/src/components/Signup/__snapshots__/Signup.test.jsx.snap
+++ b/src/components/Signup/__snapshots__/Signup.test.jsx.snap
@@ -1,28 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Signup should match the snapshot 1`] = `
-<div>
-  <Formik
-    initialValues={
-      Object {
-        "email": "",
-        "first_name": "",
-        "last_name": "",
-        "password": "",
-        "phone": "",
-      }
-    }
-    onSubmit={[Function]}
-  >
-    <Component />
-  </Formik>
-  <p>
-    Already have an account?
-  </p>
-  <a
-    href="/"
-  >
-    Sign In
-  </a>
-</div>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;

--- a/src/components/Signup/__snapshots__/Signup.test.jsx.snap
+++ b/src/components/Signup/__snapshots__/Signup.test.jsx.snap
@@ -1,7 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Signup should match the snapshot 1`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<div>
+  <Formik
+    initialValues={
+      Object {
+        "email": "",
+        "firstname": "",
+        "lastname": "",
+        "password": "",
+        "phone": "",
+        "username": "",
+      }
+    }
+    onSubmit={[Function]}
+  >
+    <Component />
+  </Formik>
+  <p>
+    Already have an account?
+  </p>
+  <a
+    href="/"
+  >
+    Sign In
+  </a>
+</div>
 `;


### PR DESCRIPTION
This PR finishes setting up user registration.
Now users can register using the signup form.

To test this PR:
1. Go to the signup form `/signup`. Make sure your server is running!
2. Register a new user. Make sure that **email** and **username** are unique and not in our db already.
![Screen Shot 2020-03-10 at 1 26 16 PM](https://user-images.githubusercontent.com/25853876/76341901-0eda5580-62d4-11ea-98b9-75532113ed24.png)
3. After registering, you should be redirected to the trip form.
You should also be able to check that the new user was added to the database:
![Screen Shot 2020-03-10 at 1 25 21 PM](https://user-images.githubusercontent.com/25853876/76342068-52cd5a80-62d4-11ea-917d-0369b39b8836.png)
4. If you want you can try and register another user using the same username or email. You won't see errors on the form itself but you will see **error 500** on the console. I'm creating a separate ticket to display these errors to users but I won't be doing it as part of this ticket because we have other things we need to move on to now.