### PR TITLE
Trip Form Fix (CA-50)

### DIFF
--- a/src/components/BigButton/BigButton.js
+++ b/src/components/BigButton/BigButton.js
@@ -1,9 +1,14 @@
 import React from 'react';
 import './BigButton.scss';
 
-function BigButton({ value, onClick }) {
+function BigButton({ value, onClick, type, disabled }) {
 	return (
-		<button className="big-button" type="Submit" onClick={onClick}>
+		<button
+			className='big-button'
+			type={type}
+			onClick={onClick}
+			disabled={disabled}
+		>
 			{value}
 		</button>
 	);

--- a/src/components/TripForm/TripForm.jsx
+++ b/src/components/TripForm/TripForm.jsx
@@ -12,7 +12,7 @@ export class TripContainer extends React.Component {
 
 	constructor(props) {
 		super(props);
-		this.state = { page: 1, values: props.initialValues };
+		this.state = { page: 0, values: props.initialValues };
 	}
 
 	nextPage = event => {
@@ -55,16 +55,16 @@ export class TripContainer extends React.Component {
 					<>
 						{activePage}
 						<div className='tripFormBtns'>
-							{page === 1 && (
+							{page === 0 && (
 								<BigButton value={'Next'} onClick={this.nextPage} />
 							)}
-							{page === 2 && (
+							{page === 1 && (
 								<>
 									<BigButton value={'Previous'} onClick={this.previousPage} />
 									<BigButton value={'Next'} onClick={this.nextPage} />
 								</>
 							)}
-							{page === 3 && (
+							{page === 2 && (
 								<>
 									<BigButton value={'Previous'} onClick={this.previousPage} />
 									<BigButton value={'Submit'} onClick={this.onSubmit} />

--- a/src/components/TripForm/TripForm.jsx
+++ b/src/components/TripForm/TripForm.jsx
@@ -2,73 +2,104 @@ import React from 'react';
 import { Formik } from 'formik';
 
 import Navbar from '../Navbar/Navbar';
+import BigButton from '../BigButton/BigButton';
 import TripInformation from './TripInformation';
 import TripGuests from './TripGuests';
 import TripRestStops from './TripRestStops';
 
-export class TripForm extends React.Component {
+export class TripContainer extends React.Component {
+	static Page = ({ children }) => children;
+
 	constructor(props) {
 		super(props);
-		this.nextPage = this.nextPage.bind(this);
-		this.previousPage = this.previousPage.bind(this);
-		this.state = { page: 1 };
+		this.state = { page: 1, values: props.initialValues };
 	}
 
-	nextPage(evt) {
-		evt.preventDefault();
+	nextPage = event => {
+		event.preventDefault();
 		this.setState({ page: this.state.page + 1 });
-	}
+	};
 
-	previousPage() {
+	previousPage = () => {
 		this.setState({ page: this.state.page - 1 });
-	}
+	};
+
+	validate = values => {
+		const activePage = React.Children.toArray(this.props.children)[
+			this.state.page
+		];
+		return activePage.props.validate ? activePage.props.validate(values) : {};
+	};
 
 	onSubmit() {
 		console.log('submitted');
 	}
 
 	render() {
+		const { children } = this.props;
+		const { page, values } = this.state;
+		const activePage = React.Children.toArray(children)[page];
+
 		return (
-			<div>
+			<>
 				<Navbar />
 				<h1 className='header-text'>New Trip</h1>
 				<Formik
-					initialValues={{
-						start_location: '',
-						destination: '',
-						start_date: '',
-						start_time: '',
-						guests: '',
-						rest_stops: '',
-					}}
+					initialValues={values}
+					validate={this.validate}
 					onSubmit={values => {
 						// same shape as initial values
 						console.log(values);
 					}}
 				>
-					{() => (
-						<>
-							{this.state.page === 1 && (
-								<TripInformation handleSubmit={this.nextPage} />
+					<>
+						{activePage}
+						<div className='tripFormBtns'>
+							{page === 1 && (
+								<BigButton value={'Next'} onClick={this.nextPage} />
 							)}
-							{this.state.page === 2 && (
-								<TripGuests
-									handleSubmit={this.nextPage}
-									handleBack={this.previousPage}
-								/>
+							{page === 2 && (
+								<>
+									<BigButton value={'Previous'} onClick={this.previousPage} />
+									<BigButton value={'Next'} onClick={this.nextPage} />
+								</>
 							)}
-							{this.state.page === 3 && (
-								<TripRestStops
-									handleSubmit={this.onSubmit}
-									handleBack={this.previousPage}
-								/>
+							{page === 3 && (
+								<>
+									<BigButton value={'Previous'} onClick={this.previousPage} />
+									<BigButton value={'Submit'} onClick={this.onSubmit} />
+								</>
 							)}
-						</>
-					)}
+						</div>
+					</>
 				</Formik>
-			</div>
+			</>
 		);
 	}
 }
+const TripForm = () => (
+	<>
+		<TripContainer
+			initialValues={{
+				start_location: '',
+				destination: '',
+				start_date: '',
+				start_time: '',
+				guests: '',
+				rest_stops: '',
+			}}
+		>
+			<TripContainer.Page>
+				<TripInformation />
+			</TripContainer.Page>
+			<TripContainer.Page>
+				<TripGuests />
+			</TripContainer.Page>
+			<TripContainer.Page>
+				<TripRestStops />
+			</TripContainer.Page>
+		</TripContainer>
+	</>
+);
 
 export default TripForm;

--- a/src/components/TripForm/TripForm.jsx
+++ b/src/components/TripForm/TripForm.jsx
@@ -6,7 +6,7 @@ import TripInformation from './TripInformation';
 import TripGuests from './TripGuests';
 import TripRestStops from './TripRestStops';
 
-class TripContainer extends React.Component {
+export class TripContainer extends React.Component {
 	static Page = ({ children }) => children;
 
 	constructor(props) {

--- a/src/components/TripForm/TripForm.jsx
+++ b/src/components/TripForm/TripForm.jsx
@@ -28,7 +28,7 @@ export class TripContainer extends React.Component {
 			page: Math.max(state.page - 1, 0),
 		}));
 
-	onSubmit = (values, bag) => {
+	handleSubmit = (values, bag) => {
 		const { children, onSubmit } = this.props;
 		const { page } = this.state;
 		const isLastPage = page === React.Children.count(children) - 1;

--- a/src/components/TripForm/TripForm.jsx
+++ b/src/components/TripForm/TripForm.jsx
@@ -17,25 +17,18 @@ class TripContainer extends React.Component {
 		};
 	}
 
-	next = values =>
+	nextPage = values =>
 		this.setState(state => ({
 			page: Math.min(state.page + 1, this.props.children.length - 1),
 			values,
 		}));
 
-	previous = () =>
+	previousPage = () =>
 		this.setState(state => ({
 			page: Math.max(state.page - 1, 0),
 		}));
 
-	validate = values => {
-		const activePage = React.Children.toArray(this.props.children)[
-			this.state.page
-		];
-		return activePage.props.validate ? activePage.props.validate(values) : {};
-	};
-
-	handleSubmit = (values, bag) => {
+	onSubmit = (values, bag) => {
 		const { children, onSubmit } = this.props;
 		const { page } = this.state;
 		const isLastPage = page === React.Children.count(children) - 1;
@@ -44,7 +37,7 @@ class TripContainer extends React.Component {
 		} else {
 			bag.setTouched({});
 			bag.setSubmitting(false);
-			this.next(values);
+			this.nextPage(values);
 		}
 	};
 
@@ -57,7 +50,6 @@ class TripContainer extends React.Component {
 			<Formik
 				initialValues={values}
 				enableReinitialize={false}
-				validate={this.validate}
 				onSubmit={this.handleSubmit}
 				render={({ values, handleSubmit, isSubmitting, handleReset }) => (
 					<form onSubmit={handleSubmit}>
@@ -66,7 +58,7 @@ class TripContainer extends React.Component {
 							{page > 0 && (
 								<BigButton
 									type='button'
-									onClick={this.previous}
+									onClick={this.previousPage}
 									value='Previous'
 								/>
 							)}

--- a/src/components/TripForm/TripForm.test.jsx
+++ b/src/components/TripForm/TripForm.test.jsx
@@ -10,13 +10,13 @@ describe('TripForm', () => {
 });
 describe('NextPage()', () => {
 	it('changes pages from 1 to 2 then 3', () => {
-		const wrapper = shallow(<TripContainer />);
+		const wrapper = shallow(<TripContainer children={[1, 2, 3]} />);
 		const instance = wrapper.instance();
+		expect(instance.state.page).toBe(0);
+		instance.nextPage({ preventDefault: jest.fn() });
 		expect(instance.state.page).toBe(1);
 		instance.nextPage({ preventDefault: jest.fn() });
 		expect(instance.state.page).toBe(2);
-		instance.nextPage({ preventDefault: jest.fn() });
-		expect(instance.state.page).toBe(3);
 	});
 });
 describe('PreviousPage()', () => {

--- a/src/components/TripForm/TripForm.test.jsx
+++ b/src/components/TripForm/TripForm.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import TripForm from './TripForm';
+import TripForm, { TripContainer } from './TripForm';
 
 describe('TripForm', () => {
 	it('should match the snapshot', () => {
@@ -10,7 +10,7 @@ describe('TripForm', () => {
 });
 describe('NextPage()', () => {
 	it('changes pages from 1 to 2 then 3', () => {
-		const wrapper = shallow(<TripForm />);
+		const wrapper = shallow(<TripContainer />);
 		const instance = wrapper.instance();
 		expect(instance.state.page).toBe(1);
 		instance.nextPage({ preventDefault: jest.fn() });
@@ -21,7 +21,7 @@ describe('NextPage()', () => {
 });
 describe('PreviousPage()', () => {
 	it('changes pages from 3 to 2 then 1', () => {
-		const wrapper = shallow(<TripForm />);
+		const wrapper = shallow(<TripContainer />);
 		const instance = wrapper.instance();
 		wrapper.setState({ page: 3 });
 		instance.previousPage({ preventDefault: jest.fn() });

--- a/src/components/TripForm/TripGuests.jsx
+++ b/src/components/TripForm/TripGuests.jsx
@@ -2,10 +2,9 @@ import React from 'react';
 import { Field, Form } from 'formik';
 import '../../utilities/fonts.scss';
 import Input from '../Input/Input';
-import BigButton from '../BigButton/BigButton';
 import { required } from '../../utilities/formValidation';
 
-const TripGuests = ({ handleBack, handleSubmit }) => (
+const TripGuests = () => (
 	<Form>
 		<Field
 			icon='group_add'
@@ -16,8 +15,6 @@ const TripGuests = ({ handleBack, handleSubmit }) => (
 			autoFocus={true}
 			component={Input}
 		/>
-		<BigButton value={'Back'} onClick={handleBack} />
-		<BigButton value={'Next'} onClick={handleSubmit} />
 	</Form>
 );
 

--- a/src/components/TripForm/TripGuests.jsx
+++ b/src/components/TripForm/TripGuests.jsx
@@ -5,7 +5,7 @@ import Input from '../Input/Input';
 import { required } from '../../utilities/formValidation';
 
 const TripGuests = () => (
-	<Form>
+	<>
 		<Field
 			icon='group_add'
 			type='text'
@@ -15,7 +15,7 @@ const TripGuests = () => (
 			autoFocus={true}
 			component={Input}
 		/>
-	</Form>
+	</>
 );
 
 export default TripGuests;

--- a/src/components/TripForm/TripInformation.jsx
+++ b/src/components/TripForm/TripInformation.jsx
@@ -2,10 +2,9 @@ import React from 'react';
 import { Field, Form } from 'formik';
 import '../../utilities/fonts.scss';
 import Input from '../Input/Input';
-import BigButton from '../BigButton/BigButton';
 import { required } from '../../utilities/formValidation';
 
-const TripInformation = ({ handleSubmit }) => (
+const TripInformation = () => (
 	<Form>
 		<Field
 			icon='trip_origin'
@@ -43,7 +42,6 @@ const TripInformation = ({ handleSubmit }) => (
 			autoFocus={false}
 			component={Input}
 		/>
-		<BigButton value={'Next'} onClick={handleSubmit} />
 	</Form>
 );
 

--- a/src/components/TripForm/TripInformation.jsx
+++ b/src/components/TripForm/TripInformation.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Field, Form } from 'formik';
+import { Field, Form, ErrorMessage } from 'formik';
 import '../../utilities/fonts.scss';
 import Input from '../Input/Input';
 import { required } from '../../utilities/formValidation';
@@ -14,6 +14,11 @@ const TripInformation = () => (
 			validate={required}
 			autoFocus={true}
 			component={Input}
+		/>
+		<ErrorMessage
+			name='start_location'
+			component='div'
+			className='field-error'
 		/>
 		<Field
 			icon='location_city'

--- a/src/components/TripForm/TripInformation.jsx
+++ b/src/components/TripForm/TripInformation.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Field, Form, ErrorMessage } from 'formik';
+import { Field } from 'formik';
 import '../../utilities/fonts.scss';
 import Input from '../Input/Input';
 import { required } from '../../utilities/formValidation';
 
 const TripInformation = () => (
-	<Form>
+	<>
 		<Field
 			icon='trip_origin'
 			type='text'
@@ -14,11 +14,6 @@ const TripInformation = () => (
 			validate={required}
 			autoFocus={true}
 			component={Input}
-		/>
-		<ErrorMessage
-			name='start_location'
-			component='div'
-			className='field-error'
 		/>
 		<Field
 			icon='location_city'
@@ -47,7 +42,7 @@ const TripInformation = () => (
 			autoFocus={false}
 			component={Input}
 		/>
-	</Form>
+	</>
 );
 
 export default TripInformation;

--- a/src/components/TripForm/TripRestStops.jsx
+++ b/src/components/TripForm/TripRestStops.jsx
@@ -4,7 +4,7 @@ import '../../utilities/fonts.scss';
 import Input from '../Input/Input';
 
 const TripRestStops = () => (
-	<Form>
+	<>
 		<Field
 			icon='location_on'
 			type='text'
@@ -13,7 +13,7 @@ const TripRestStops = () => (
 			autoFocus={true}
 			component={Input}
 		/>
-	</Form>
+	</>
 );
 
 export default TripRestStops;

--- a/src/components/TripForm/TripRestStops.jsx
+++ b/src/components/TripForm/TripRestStops.jsx
@@ -2,9 +2,8 @@ import React from 'react';
 import { Field, Form } from 'formik';
 import '../../utilities/fonts.scss';
 import Input from '../Input/Input';
-import BigButton from '../BigButton/BigButton';
 
-const TripRestStops = ({ handleBack, handleSubmit }) => (
+const TripRestStops = () => (
 	<Form>
 		<Field
 			icon='location_on'
@@ -14,8 +13,6 @@ const TripRestStops = ({ handleBack, handleSubmit }) => (
 			autoFocus={true}
 			component={Input}
 		/>
-		<BigButton value={'Back'} onClick={handleBack} />
-		<BigButton value={'Submit'} onClick={handleSubmit} />
 	</Form>
 );
 

--- a/src/components/TripForm/__snapshots__/TripForm.test.jsx.snap
+++ b/src/components/TripForm/__snapshots__/TripForm.test.jsx.snap
@@ -1,14 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TripForm should match the snapshot 1`] = `
-<div>
-  <Navbar />
-  <h1
-    className="header-text"
-  >
-    New Trip
-  </h1>
-  <Formik
+<Fragment>
+  <TripContainer
     initialValues={
       Object {
         "destination": "",
@@ -19,9 +13,16 @@ exports[`TripForm should match the snapshot 1`] = `
         "start_time": "",
       }
     }
-    onSubmit={[Function]}
   >
-    <Component />
-  </Formik>
-</div>
+    <Component>
+      <TripInformation />
+    </Component>
+    <Component>
+      <TripGuests />
+    </Component>
+    <Component>
+      <TripRestStops />
+    </Component>
+  </TripContainer>
+</Fragment>
 `;

--- a/src/components/TripForm/__snapshots__/TripGuests.test.jsx.snap
+++ b/src/components/TripForm/__snapshots__/TripGuests.test.jsx.snap
@@ -11,11 +11,5 @@ exports[`TripGuests should match the snapshot 1`] = `
     type="text"
     validate={[Function]}
   />
-  <BigButton
-    value="Back"
-  />
-  <BigButton
-    value="Next"
-  />
 </Form>
 `;

--- a/src/components/TripForm/__snapshots__/TripGuests.test.jsx.snap
+++ b/src/components/TripForm/__snapshots__/TripGuests.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TripGuests should match the snapshot 1`] = `
-<Form>
+<Fragment>
   <Field
     autoFocus={true}
     component={[Function]}
@@ -11,5 +11,5 @@ exports[`TripGuests should match the snapshot 1`] = `
     type="text"
     validate={[Function]}
   />
-</Form>
+</Fragment>
 `;

--- a/src/components/TripForm/__snapshots__/TripInformation.test.jsx.snap
+++ b/src/components/TripForm/__snapshots__/TripInformation.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TripInformation should match the snapshot 1`] = `
-<Form>
+<Fragment>
   <Field
     autoFocus={true}
     component={[Function]}
@@ -38,5 +38,5 @@ exports[`TripInformation should match the snapshot 1`] = `
     type="text"
     validate={[Function]}
   />
-</Form>
+</Fragment>
 `;

--- a/src/components/TripForm/__snapshots__/TripInformation.test.jsx.snap
+++ b/src/components/TripForm/__snapshots__/TripInformation.test.jsx.snap
@@ -38,8 +38,5 @@ exports[`TripInformation should match the snapshot 1`] = `
     type="text"
     validate={[Function]}
   />
-  <BigButton
-    value="Next"
-  />
 </Form>
 `;

--- a/src/components/TripForm/__snapshots__/TripRestStops.test.jsx.snap
+++ b/src/components/TripForm/__snapshots__/TripRestStops.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TripRestStops should match the snapshot 1`] = `
-<Form>
+<Fragment>
   <Field
     autoFocus={true}
     component={[Function]}
@@ -10,5 +10,5 @@ exports[`TripRestStops should match the snapshot 1`] = `
     placeholder="Rest Stop"
     type="text"
   />
-</Form>
+</Fragment>
 `;

--- a/src/components/TripForm/__snapshots__/TripRestStops.test.jsx.snap
+++ b/src/components/TripForm/__snapshots__/TripRestStops.test.jsx.snap
@@ -10,11 +10,5 @@ exports[`TripRestStops should match the snapshot 1`] = `
     placeholder="Rest Stop"
     type="text"
   />
-  <BigButton
-    value="Back"
-  />
-  <BigButton
-    value="Submit"
-  />
 </Form>
 `;


### PR DESCRIPTION
#### Related Issues
https://caravanning.atlassian.net/browse/CA-50

#### Description
Currently the trip form consist of:

Trip information: Start location, destination, start time and date

Trip guest: Add guests to trip

Trip rest stops: Can add rest stops or not [possibly have a button called no rest stops so the host can check it off] 

Currently the flow of  trip form: you are allowed to move back and forth between the pages of the form.
The issue is that even though the fields are not filled out, the user is able to go to the next page.
Another issue is that on the last page of the form, which is the add rest stops page, is that currently the rest stop field is required to be filled out in order to submit the trip creation form. However, the host might not want to include rest stops, so we will need to look more into this!

What we want:

require the users to fill everything in before having the ability to move onto the next page of the form. 

fix the rest stop page so that it isn't a required field to have filled in order to submit form. 

#### How to Test:
1. Run the web application by running `yarn start` or the npm equivalent: `npm start`. 
2. Open `localhost:3000/trip` in the browser
3. You should press the `Next` button. You should be prevented from clicking the next button if the value is not filled.