### PR TITLE
Trip Details Modal (CA-75)

### DIFF
--- a/src/components/SummaryCard/SummaryCard.jsx
+++ b/src/components/SummaryCard/SummaryCard.jsx
@@ -1,59 +1,58 @@
-import React, {
-  useState
-} from 'react';
-import Row from 'react-bootstrap/Row';
-import Container from 'react-bootstrap/Container';
-import Card from 'react-bootstrap/Card';
-import Button from 'react-bootstrap/Button';
+import React from 'react';
+import { Card, Modal } from 'react-bootstrap';
+
 import './SummaryCard.css';
+import TripDetails from '../TripDetails/TripDetails';
 
 export default class SummaryCard extends React.Component {
-    constructor(props) {
-      super(props);
-      this.state = {
-        tripName: '',
-        host: '',
-        destination: '',
-        show: false
-      };
-    }
+	constructor(props) {
+		super(props);
+		this.state = {
+			tripName: '',
+			host: '',
+			destination: '',
+			show: false,
+		};
+	}
 
-    componentDidMount() {
-      // TO DO: add redux to dynamically import user id
-      console.log("componentDidMount");
-      fetch('/invitations/3')
-        .then(response => {
-          return response.json();
-        })
-        .then(data => {
-          console.log(data);
-          this.setState({
-            tripName: data[0].trip_title
-          });
-          this.setState({
-            host: data[0].username
-          });
-          this.setState({ destination: data[0].destination });
-        });
-    }
+	componentDidMount() {
+		// TO DO: add redux to dynamically import user id
+		fetch('/invitations/3')
+			.then(response => {
+				return response.json();
+			})
+			.then(data => {
+				console.log(data);
+				this.setState({
+					tripName: data[0].trip_title,
+				});
+				this.setState({
+					host: data[0].username,
+				});
+				this.setState({ destination: data[0].destination });
+			});
+	}
 
-    toggleShow = bool => {
-	    this.setState({ show: bool });
-     };
+	handleClose = () => this.setState({ show: false });
+	handleShow = () => this.setState({ show: true });
 
-    render() {
-      const {show, tripName, host, destination} = this.state;
-
-      return (
-        <Card style={{ width: '18rem' }}>
-          <Card.Body>
-              <Card.Title>{tripName}</Card.Title>
-              <Card.Text>
-                <p>{host}</p>
-                <p>{destination}</p>
-              </Card.Text>
-          </Card.Body>
-        </Card>
-      );
-    };
-  }
+	render() {
+		const { show, tripName, host, destination } = this.state;
+		return (
+			<>
+				<Card style={{ width: '18rem' }} onClick={this.handleShow}>
+					<Card.Body>
+						<Card.Title>{tripName}</Card.Title>
+						<Card.Text>
+							<>{host}</>
+							<>{destination}</>
+						</Card.Text>
+					</Card.Body>
+				</Card>
+				<Modal show={show} onHide={this.handleClose}>
+					<TripDetails />
+				</Modal>
+			</>
+		);
+	}
+}

--- a/src/components/SummaryCard/SummaryCard.test.jsx
+++ b/src/components/SummaryCard/SummaryCard.test.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import SummaryCard from './SummaryCard';
+
+describe('SummaryCard', () => {
+	it('should match the snapshot', () => {
+		const wrapper = shallow(<SummaryCard />);
+		expect(wrapper).toMatchSnapshot();
+	});
+});
+describe('handleShohw', () => {
+	it('sets show to true', () => {
+		const wrapper = shallow(<SummaryCard />);
+		const instance = wrapper.instance();
+		expect(instance.state.show).toBeFalsy();
+		instance.handleShow();
+		expect(instance.state.show).toBeTruthy();
+	});
+});
+describe('handleClose', () => {
+	it('sets show to false', () => {
+		const wrapper = shallow(<SummaryCard />);
+		const instance = wrapper.instance();
+		wrapper.setState({ show: true });
+		instance.handleClose();
+		expect(instance.state.show).toBeFalsy();
+	});
+});

--- a/src/components/SummaryCard/__snapshots__/SummaryCard.test.jsx.snap
+++ b/src/components/SummaryCard/__snapshots__/SummaryCard.test.jsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SummaryCard should match the snapshot 1`] = `
+<Fragment>
+  <Card
+    body={false}
+    onClick={[Function]}
+    style={
+      Object {
+        "width": "18rem",
+      }
+    }
+  >
+    <CardBody>
+      <CardTitle />
+      <CardText />
+    </CardBody>
+  </Card>
+  <Bootstrap(Modal)
+    onHide={[Function]}
+    show={false}
+  >
+    <TripDetails />
+  </Bootstrap(Modal)>
+</Fragment>
+`;

--- a/src/components/TripForm/TripGuests.jsx
+++ b/src/components/TripForm/TripGuests.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Field, Form } from 'formik';
+import { Field } from 'formik';
 import '../../utilities/fonts.scss';
 import Input from '../Input/Input';
 import { required } from '../../utilities/formValidation';

--- a/src/components/TripForm/TripRestStops.jsx
+++ b/src/components/TripForm/TripRestStops.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Field, Form } from 'formik';
+import { Field } from 'formik';
 import '../../utilities/fonts.scss';
 import Input from '../Input/Input';
 


### PR DESCRIPTION
## Related Issues
https://caravanning.atlassian.net/browse/CA-75

## Description
Open Trip Details when you click the summary card component.
###### DoD:
- Onclick of the summary component, open the trip details component in a modal.
###### Resources
- https://react-bootstrap.netlify.com/components/modal/#modals

## Testing
Add a step-by-step list on how to test this PR, like this:
- [ ] Run the React Client Application using `yarn start` (or npm start)
- [ ] Run the server by running `node server.js`
- [ ] Navigate to `localhost:3000/summarycard` in your browser
- [ ] Click on the summary card component and you should see the trip details modal pop up like in the image below: 
![Modal](https://user-images.githubusercontent.com/7966507/77653874-a7184180-6f46-11ea-9f97-da97d871c360.gif)

## How are you feeling?
🥇 🏃‍♀ 🎽 