### PR TITLE
CA-106 create start trip button

### DIFF
--- a/src/components/TripDetails/TripDetails.jsx
+++ b/src/components/TripDetails/TripDetails.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from 'react-bootstrap';
 
 import './TripDetails.scss';
 
@@ -54,6 +56,10 @@ const TripDetails = props => {
 						<li>@guestB</li>
 						<li>@guestC</li>
 					</ul>
+
+					<Link to='/map'>
+						<Button variant='success'>Start Trip</Button>
+					</Link>
 				</div>
 			</div>
 		</div>

--- a/src/components/TripDetails/__snapshots__/TripDetails.test.jsx.snap
+++ b/src/components/TripDetails/__snapshots__/TripDetails.test.jsx.snap
@@ -85,6 +85,18 @@ exports[`Trip Details should match the snapshot 1`] = `
           @guestC
         </li>
       </ul>
+      <Link
+        to="/map"
+      >
+        <Button
+          active={false}
+          disabled={false}
+          type="button"
+          variant="success"
+        >
+          Start Trip
+        </Button>
+      </Link>
     </div>
   </div>
 </div>


### PR DESCRIPTION
🚨 accidentally mislabeled this branch CA-63 instead of CA-106 😳

## Related Issues
https://caravanning.atlassian.net/browse/CA-106

## Description
Created a button to start trip and have it reroute to the /map page.

## Test this PR:
- [ ] Run the server with `node server.js`
- [ ] Run application with `yarn start`
- [ ] Go to `http://localhost:3000/dashboard` in a browser
- [ ] Click on the trip and the summary card will appear. 
- [ ] Scroll to the bottom and click on the `Start trip` button and you will be routed to the map page.

![CA-106](https://user-images.githubusercontent.com/38799293/78284912-11ecee00-74ee-11ea-8a48-34ad64f3be7f.gif)


## How are you feeling?
😊