### PR TITLE
Redirect user to dashboard after signup

### DIFF
--- a/src/components/Signup/Signup.jsx
+++ b/src/components/Signup/Signup.jsx
@@ -101,7 +101,7 @@ export const Signup = props => {
 							password: values.password,
 						})
 						.then(function(response) {
-							history.push('/trip');
+							history.push('/dashboard');
 						})
 						.catch(function(error) {
 							console.log(error);


### PR DESCRIPTION
## Description
This branch redirects users to dashboard after signup. Users were being redirected to /trip before.

## Testing
Add a step-by-step list on how to test this PR, like this:
- [ ] Run the server
- [ ] Go to http://localhost:3000/signup
- [ ] Fill out the form with info for a new user
- [ ] You should be redirected to dashboard not /trip

## How are you feeling?
😫 😷 
