### PR TITLE
Leave Trip buttons

### DIFF
--- a/src/components/ActionButtons/ActionButtons.jsx
+++ b/src/components/ActionButtons/ActionButtons.jsx
@@ -5,77 +5,87 @@ import { Link } from 'react-router-dom';
 import BigButton from '../BigButton/BigButton';
 import './ActionButtons.scss';
 
-const responseToInvitation = (response) => {
-	const { userid, tripid, accepted } = response;
-
-	axios
-		.post('/invitations/accept', {
-			userid,
-			tripid,
-			accepted,
-		})
-		.then(function (response) {
-			console.log(response);
-		})
-		.catch(function (error) {
-			console.log(error);
-		});
-};
-
-const ActionButtons = (response) => {
-	const { userid, tripid, accepted } = response;
-
-	if (accepted === false) {
-		//user has rejected invitation buttons
-		return (
-			<div className='rejected-msg'>
-				<p>You declined this invitation. Changed your mind?</p>
-				<div className='invitation-btns two-btns'>
-					<BigButton
-						value={'Accept Invitation'}
-						onClick={() => {
-							responseToInvitation({ userid, tripid, accepted: true });
-						}}
-					/>
-					<BigButton value={'Request Change'} />
-				</div>
-			</div>
-		);
-	} else if (accepted === true) {
-		//user has accepted invitation buttons
-		return (
-			<div className='invitation-btns two-btns'>
-				<Link to='/map'>
-					<BigButton value={'Start Trip'} />
-				</Link>
-				<BigButton
-					value={'Leave Trip'}
-					onClick={() => {
-						responseToInvitation({ userid, tripid, accepted: false });
-					}}
-				/>
-			</div>
-		);
-	} else {
-		// user was invited but has neither accepted or rejected the invitation yet
-		return (
-			<div className='invitation-btns three-btns'>
-				<BigButton
-					value={'Accept'}
-					onClick={() => {
-						responseToInvitation({ userid, tripid, accepted: true });
-					}}
-				/>
-				<BigButton
-					value={'Reject'}
-					onClick={() => {
-						responseToInvitation({ userid, tripid, accepted: false });
-					}}
-				/>
-				<BigButton value={'Request Change'} />
-			</div>
-		);
+export default class ActionButtons extends React.Component {
+	constructor(props) {
+		super(props);
+		this.state = {
+			accepted: this.props.accepted,
+		};
 	}
-};
 
-export default ActionButtons;
+	responseToInvitation = () => {
+		axios
+			.post('/invitations/accept', {
+				userid: this.props.userid,
+				tripid: this.props.tripid,
+				accepted: this.state.accepted,
+			})
+			.then(function (response) {
+				console.log(response);
+			})
+			.catch(function (error) {
+				console.log(error);
+			});
+	};
+
+	acceptInvitationButton = (value) => {
+		return (
+			<BigButton
+				value={value}
+				onClick={() => {
+					this.setState({ accepted: true }, function () {
+						this.responseToInvitation();
+					});
+				}}
+			/>
+		);
+	};
+
+	rejectInvitationButton = (value) => {
+		return (
+			<BigButton
+				value={value}
+				onClick={() => {
+					this.setState({ accepted: false }, function () {
+						this.responseToInvitation();
+					});
+				}}
+			/>
+		);
+	};
+
+	requestChangeButton = () => {
+		return <BigButton value={'Request Change'} />;
+	};
+
+	render() {
+		if (this.state.accepted === false) {
+			return (
+				<div className='rejected-msg'>
+					<p>You declined this invitation. Changed your mind?</p>
+					<div className='invitation-btns two-btns'>
+						{this.acceptInvitationButton('Accept Invitation')}
+						{this.requestChangeButton()}
+					</div>
+				</div>
+			);
+		} else if (this.state.accepted === true) {
+			return (
+				<div className='invitation-btns two-btns'>
+					<Link to='/map'>
+						<BigButton value={'Start Trip'} />
+					</Link>
+					{this.rejectInvitationButton('Leave Trip')}
+				</div>
+			);
+		} else {
+			return (
+				<div className='invitation-btns three-btns'>
+					{this.acceptInvitationButton('Accept')}
+					{this.rejectInvitationButton('Reject')}
+					{this.requestChangeButton()}
+				</div>
+			);
+		}
+	}
+}

--- a/src/components/ActionButtons/ActionButtons.jsx
+++ b/src/components/ActionButtons/ActionButtons.jsx
@@ -7,7 +7,8 @@ import './ActionButtons.scss';
 
 const responseToInvitation = (response) => {
 	const { userid, tripid, responseCode } = response;
-
+	// responseCode == 1 accepted
+	// responseCode == 2 rejected
 	if (responseCode === 1) {
 		axios
 			.post('/invitations/accept', {
@@ -43,10 +44,11 @@ const ActionButtons = (response) => {
 	let responseCode = 0;
 
 	if (accepted === false) {
+		//user has rejected invitation buttons
 		return (
 			<div className='rejected-msg'>
 				<p>You declined this invitation. Changed your mind?</p>
-				<div className='invitation-btns rejected'>
+				<div className='invitation-btns two-btns'>
 					<BigButton
 						value={'Accept Invitation'}
 						onClick={() => {
@@ -63,16 +65,29 @@ const ActionButtons = (response) => {
 			</div>
 		);
 	} else if (accepted === true) {
+		//user has accepted invitation buttons
 		return (
-			<div className='invitation-btns'>
-				<Link to='/map' className='start-trip-btn'>
+			<div className='invitation-btns two-btns'>
+				<Link to='/map'>
 					<BigButton value={'Start Trip'} />
 				</Link>
+				<BigButton
+					value={'Leave Trip'}
+					onClick={() => {
+						responseCode = 2;
+						responseToInvitation({
+							userid,
+							tripid,
+							responseCode,
+						});
+					}}
+				/>
 			</div>
 		);
 	} else {
+		// user was invited but has neither accept or rejected the invitation yet
 		return (
-			<div className='invitation-btns'>
+			<div className='invitation-btns three-btns'>
 				<BigButton
 					value={'Accept'}
 					onClick={() => {

--- a/src/components/ActionButtons/ActionButtons.scss
+++ b/src/components/ActionButtons/ActionButtons.scss
@@ -1,24 +1,25 @@
 @import '../../utilities/colorPalette.scss';
 
-.invitation-btns {
+.invitation-btns.one-btn {
 	.big-button {
-		width: 33.333333%;
-	}
-
-	.start-trip-btn .big-button {
 		width: 100%;
 	}
 }
+.invitation-btns.two-btns {
+	.big-button {
+		width: 50%;
+	}
+}
+.invitation-btns.three-btns {
+	.big-button {
+		width: 33.333333%;
+	}
+}
+
 .rejected-msg {
 	p {
 		margin: 10px 0;
 		text-align: center;
-	}
-
-	.invitation-btns.rejected {
-		.big-button {
-			width: 50%;
-		}
 	}
 }
 

--- a/src/components/ActionButtons/__snapshots__/ActionButtons.test.jsx.snap
+++ b/src/components/ActionButtons/__snapshots__/ActionButtons.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Action Buttons should match the snapshot 1`] = `
 <div
-  className="invitation-btns"
+  className="invitation-btns three-btns"
 >
   <BigButton
     onClick={[Function]}


### PR DESCRIPTION
## Description
After the user accepted an invitation, they will now see two buttons: Start Trip and Leave Trip, which will take them out of the trip in case they rejected the invitation

## Related Issues
This is the PR for the other actions buttons: https://github.com/jhrbva/Caravan/pull/70

## Testing
- [ ] Run the server and start the project
- [ ] Go to /dashboard and click on the trip summary card
- [ ] When the modal pops open you should see this:
![Screen Shot 2020-04-09 at 3 20 50 PM](https://user-images.githubusercontent.com/25853876/78937690-8a1b5c80-7a76-11ea-9bc1-102962c7dfb2.png)
- [ ] Click on Leave Trip
- [ ] Refresh the page, click on the summary card again. You should see this:
![Screen Shot 2020-04-09 at 3 03 30 PM](https://user-images.githubusercontent.com/25853876/78937774-a7e8c180-7a76-11ea-91ed-1ce0f455b545.png)
- [ ] If you want, you can play around with clicking on Accept again and refreshing, that should take you back to the first screen shot. If you do take this step, don't forget to click on 'Leave Trip' again so that the next reviewer can follow these same instructions 

## How are you feeling?
🧑‍🏭 
