### PR TITLE
adding map snippet to trip modal

### DIFF
--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -19,7 +19,7 @@ export default class Dashboard extends React.Component {
 	componentDidMount() {
 		// TO DO: add redux to dynamically import user id
 		Promise.all([
-			fetch('/invitations/3'),
+			fetch('/invitations/1'),
 			fetch('/trips/2'),
 			fetch('/members/1'),
 			fetch('/reststop/1'),

--- a/src/components/Map/MapSnippet.jsx
+++ b/src/components/Map/MapSnippet.jsx
@@ -1,0 +1,80 @@
+/*global google*/
+import React from 'react';
+import { compose, withProps, lifecycle } from 'recompose';
+import {
+	withScriptjs,
+	withGoogleMap,
+	GoogleMap,
+	DirectionsRenderer,
+	Marker,
+} from 'react-google-maps';
+import { geolocated } from 'react-geolocated';
+
+const MapSnippet = compose(
+	withProps({
+		googleMapURL: `https://maps.googleapis.com/maps/api/js?key=${process.env.REACT_APP_API_KEY}&v=3.exp&libraries=geometry,drawing,places`,
+		loadingElement: <div style={{ height: `100%` }} />,
+		containerElement: <div style={{ height: `100%`, width: `100%` }} />,
+		mapElement: <div style={{ height: `100%` }} />,
+		iconLabel: 'TC',
+		iconColor: '#3d6cb9',
+	}),
+	withScriptjs,
+	withGoogleMap,
+	geolocated(),
+	lifecycle({
+		componentDidMount() {
+			const DirectionsService = new google.maps.DirectionsService();
+			DirectionsService.route(
+				{
+					origin: new google.maps.LatLng(40.604279, -74.400543),
+					destination: new google.maps.LatLng(41.85258, -87.65141),
+					travelMode: google.maps.TravelMode.DRIVING,
+				},
+				(result, status) => {
+					console.log(result.routes[0].legs[0].steps[0].start_location.lat());
+					if (status === google.maps.DirectionsStatus.OK) {
+						this.setState({
+							directions: result,
+						});
+					} else {
+						console.error(`error fetching directions ${result}`);
+					}
+				}
+			);
+		},
+	})
+)((props) => {
+	return (
+		<GoogleMap
+			defaultZoom={2}
+			defaultCenter={new google.maps.LatLng(41.85073, -87.65126)}
+		>
+			{props.directions && <DirectionsRenderer directions={props.directions} />}
+			{props.coords && (
+				<Marker
+					position={{ lat: props.coords.latitude, lng: props.coords.longitude }}
+					icon={{
+						path: google.maps.SymbolPath.BACKWARD_CLOSED_ARROW,
+						fillColor: props.iconColor,
+						fillOpacity: 0.8,
+						scale: 8,
+						strokeColor: props.iconColor,
+						strokeWeight: 0.8,
+						rotation: 270,
+						labelOrigin: new google.maps.Point(0, -2.5),
+					}}
+					label={{
+						text: props.iconLabel,
+						color: 'white',
+						fontSize: '9px',
+						fontWeight: 'bold',
+						fontFamily: 'Helvetica',
+					}}
+				/>
+			)}
+		</GoogleMap>
+	);
+});
+
+export default MapSnippet;

--- a/src/components/TripDetails/TripDetails.jsx
+++ b/src/components/TripDetails/TripDetails.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import ActionButtons from '../ActionButtons/ActionButtons';
 import './TripDetails.scss';
+import ActionButtons from '../ActionButtons/ActionButtons';
+import MapSnippet from '../Map/MapSnippet';
 
 export const getDateTime = (date) => {
 	const tripDate = date.slice(0, 10);
@@ -45,6 +46,9 @@ const TripDetails = (props) => {
 				<div className='trip-details-header'>
 					<h1 className='header-text'>{trip_title}</h1>
 					<h2 className='header-text-light'>{trip_description}</h2>
+				</div>
+				<div className='map-snippet'>
+					<MapSnippet />
 				</div>
 				<div className='trip-details'>
 					<p>

--- a/src/components/TripDetails/TripDetails.scss
+++ b/src/components/TripDetails/TripDetails.scss
@@ -15,3 +15,7 @@
 	font-weight: bold;
 	font-size: 18px;
 }
+.map-snippet {
+	width: 100%;
+	height: 200px;
+}

--- a/src/components/TripDetails/__snapshots__/TripDetails.test.jsx.snap
+++ b/src/components/TripDetails/__snapshots__/TripDetails.test.jsx.snap
@@ -20,6 +20,11 @@ exports[`Trip Details should match the snapshot 1`] = `
       </h2>
     </div>
     <div
+      className="map-snippet"
+    >
+      <withProps(withScriptjs(withGoogleMap(Geolocated(lifecycle(Component))))) />
+    </div>
+    <div
       className="trip-details"
     >
       <p>


### PR DESCRIPTION
## Description
Adds a map snippet to the trip details modal showing point A and B of the trip 

## Testing
Add a step-by-step list on how to test this PR, like this:
- [ ] Run the server and start app
- [ ] Go to dashboard and click on a trip card
- [ ] You should see a map snippet like this:
![Screen Shot 2020-04-24 at 10 49 52 AM](https://user-images.githubusercontent.com/25853876/80231853-97f5e380-8619-11ea-8d36-6d9aad2edb8c.png)


## How are you feeling?
😒 
