### PR TITLE
Ca 178 arrows for maneuver

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -46,10 +46,6 @@ h3 {
 	font-family: 'Fredoka One', sans-serif;
 	font-size: 25px !important;
 }
-h4 {
-	font-family: 'Quicksand', sans-serif;
-	font-size: 30px !important;
-}
 textarea {
 	display: block;
 	font-size: 12px;

--- a/src/App.scss
+++ b/src/App.scss
@@ -46,6 +46,10 @@ h3 {
 	font-family: 'Fredoka One', sans-serif;
 	font-size: 25px !important;
 }
+h4 {
+	font-family: 'Quicksand', sans-serif;
+	font-size: 30px !important;
+}
 textarea {
 	display: block;
 	font-size: 12px;

--- a/src/components/Map/InstructionalArrows.jsx
+++ b/src/components/Map/InstructionalArrows.jsx
@@ -1,0 +1,62 @@
+// this file inports all the arrows needed for the turn-by-turn
+// instructions and passes them to the instructional overlay
+
+import React from 'react';
+import NavigationIcon from '@material-ui/icons/Navigation';
+import ArrowBackIcon from '@material-ui/icons/ArrowBack';
+import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
+import CallMadeIcon from '@material-ui/icons/CallMade';
+import UndoIcon from '@material-ui/icons/Undo';
+import RedoIcon from '@material-ui/icons/Redo';
+import RotateRightIcon from '@material-ui/icons/RotateRight';
+import RotateLeftIcon from '@material-ui/icons/RotateLeft';
+import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
+import DirectionsBoatIcon from '@material-ui/icons/DirectionsBoat';
+import TrainIcon from '@material-ui/icons/Train';
+import MergeTypeIcon from '@material-ui/icons/MergeType';
+import CallSplitIcon from '@material-ui/icons/CallSplit';
+
+const InstructionalArrows = (maneuver) => {
+	switch (maneuver.maneuver) {
+		case 'straight':
+			return <ArrowUpwardIcon style={{ fontSize: 80 }} />;
+		case 'merge':
+			return <MergeTypeIcon style={{ fontSize: 80 }} />;
+		case 'ferry':
+			return <DirectionsBoatIcon style={{ fontSize: 80 }} />;
+		case 'ferry-train':
+			return <TrainIcon style={{ fontSize: 80 }} />;
+		case 'turn-sharp-left':
+			return <ArrowBackIcon style={{ fontSize: 80 }} />;
+		case 'turn-slight-left':
+			return <ArrowBackIcon style={{ fontSize: 80 }} />;
+		case 'ramp-left':
+			return <ArrowBackIcon style={{ fontSize: 80 }} />;
+		case 'turn-left':
+			return <ArrowBackIcon style={{ fontSize: 80 }} />;
+		case 'uturn-left':
+			return <UndoIcon style={{ fontSize: 80 }} />;
+		case 'roundabout-left':
+			return <RotateLeftIcon style={{ fontSize: 80 }} />;
+		case 'fork-left':
+			return <CallSplitIcon style={{ fontSize: 80 }} />;
+		case 'turn-sharp-right':
+			return <ArrowForwardIcon style={{ fontSize: 80 }} />;
+		case 'turn-slight-right':
+			return <CallMadeIcon style={{ fontSize: 80 }} />;
+		case 'ramp-right':
+			return <CallMadeIcon style={{ fontSize: 80 }} />;
+		case 'turn-right':
+			return <ArrowForwardIcon style={{ fontSize: 80 }} />;
+		case 'uturn-right':
+			return <RedoIcon style={{ fontSize: 80 }} />;
+		case 'roundabout-right':
+			return <RotateRightIcon style={{ fontSize: 80 }} />;
+		case 'fork-right':
+			return <CallSplitIcon style={{ fontSize: 80 }} />;
+		default:
+			return <NavigationIcon style={{ fontSize: 80 }} />;
+	}
+};
+
+export default InstructionalArrows;

--- a/src/components/Map/InstructionalArrows.jsx
+++ b/src/components/Map/InstructionalArrows.jsx
@@ -14,6 +14,7 @@ import DirectionsBoatIcon from '@material-ui/icons/DirectionsBoat';
 import TrainIcon from '@material-ui/icons/Train';
 import MergeTypeIcon from '@material-ui/icons/MergeType';
 import CallSplitIcon from '@material-ui/icons/CallSplit';
+import GpsFixedIcon from '@material-ui/icons/GpsFixed';
 import './InstructionalOverlay.scss';
 
 const InstructionalArrows = (maneuver) => {
@@ -55,7 +56,7 @@ const InstructionalArrows = (maneuver) => {
 		case 'fork-right':
 			return <CallSplitIcon className={'maneuver'} />;
 		default:
-			return '';
+			return <GpsFixedIcon className={'maneuver'} />;
 	}
 };
 

--- a/src/components/Map/InstructionalArrows.jsx
+++ b/src/components/Map/InstructionalArrows.jsx
@@ -2,7 +2,6 @@
 // instructions and passes them to the instructional overlay
 
 import React from 'react';
-import NavigationIcon from '@material-ui/icons/Navigation';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import CallMadeIcon from '@material-ui/icons/CallMade';
@@ -15,47 +14,48 @@ import DirectionsBoatIcon from '@material-ui/icons/DirectionsBoat';
 import TrainIcon from '@material-ui/icons/Train';
 import MergeTypeIcon from '@material-ui/icons/MergeType';
 import CallSplitIcon from '@material-ui/icons/CallSplit';
+import './InstructionalOverlay.scss';
 
 const InstructionalArrows = (maneuver) => {
 	switch (maneuver.maneuver) {
 		case 'straight':
-			return <ArrowUpwardIcon style={{ fontSize: 80 }} />;
+			return <ArrowUpwardIcon className={'maneuver'} />;
 		case 'merge':
-			return <MergeTypeIcon style={{ fontSize: 80 }} />;
+			return <MergeTypeIcon className={'maneuver'} />;
 		case 'ferry':
-			return <DirectionsBoatIcon style={{ fontSize: 80 }} />;
+			return <DirectionsBoatIcon className={'maneuver'} />;
 		case 'ferry-train':
-			return <TrainIcon style={{ fontSize: 80 }} />;
+			return <TrainIcon className={'maneuver'} />;
 		case 'turn-sharp-left':
-			return <ArrowBackIcon style={{ fontSize: 80 }} />;
+			return <ArrowBackIcon className={'maneuver'} />;
 		case 'turn-slight-left':
-			return <ArrowBackIcon style={{ fontSize: 80 }} />;
+			return <ArrowBackIcon className={`maneuver top-left`} />;
 		case 'ramp-left':
-			return <ArrowBackIcon style={{ fontSize: 80 }} />;
+			return <ArrowBackIcon className={`maneuver top-left`} />;
 		case 'turn-left':
-			return <ArrowBackIcon style={{ fontSize: 80 }} />;
+			return <ArrowBackIcon className={'maneuver'} />;
 		case 'uturn-left':
-			return <UndoIcon style={{ fontSize: 80 }} />;
+			return <UndoIcon className={'maneuver'} />;
 		case 'roundabout-left':
-			return <RotateLeftIcon style={{ fontSize: 80 }} />;
+			return <RotateLeftIcon className={'maneuver'} />;
 		case 'fork-left':
-			return <CallSplitIcon style={{ fontSize: 80 }} />;
+			return <CallSplitIcon className={'maneuver'} />;
 		case 'turn-sharp-right':
-			return <ArrowForwardIcon style={{ fontSize: 80 }} />;
+			return <ArrowForwardIcon className={'maneuver'} />;
 		case 'turn-slight-right':
-			return <CallMadeIcon style={{ fontSize: 80 }} />;
+			return <CallMadeIcon className={'maneuver'} />;
 		case 'ramp-right':
-			return <CallMadeIcon style={{ fontSize: 80 }} />;
+			return <CallMadeIcon className={'maneuver'} />;
 		case 'turn-right':
-			return <ArrowForwardIcon style={{ fontSize: 80 }} />;
+			return <ArrowForwardIcon className={'maneuver'} />;
 		case 'uturn-right':
-			return <RedoIcon style={{ fontSize: 80 }} />;
+			return <RedoIcon className={'maneuver'} />;
 		case 'roundabout-right':
-			return <RotateRightIcon style={{ fontSize: 80 }} />;
+			return <RotateRightIcon className={'maneuver'} />;
 		case 'fork-right':
-			return <CallSplitIcon style={{ fontSize: 80 }} />;
+			return <CallSplitIcon className={'maneuver'} />;
 		default:
-			return <NavigationIcon style={{ fontSize: 80 }} />;
+			return '';
 	}
 };
 

--- a/src/components/Map/InstructionalOverlay.jsx
+++ b/src/components/Map/InstructionalOverlay.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import InstructionalArrows from './InstructionalArrows';
-import { Row, Col } from 'react-bootstrap';
 import './InstructionalOverlay.scss';
 
 export default class InstructionalOverlay extends React.Component {
@@ -26,48 +25,22 @@ export default class InstructionalOverlay extends React.Component {
 	};
 
 	componentDidMount = () => {
-		const testDirections = {
-			instruction: [
-				[40.7, -74.0, 'turn-sharp-left', 'turn-sharp-left'],
-				[40.7, -74.0, 'turn-slight-left', 'turn-slight-left'],
-				[40.7, -74.0, 'uturn-left', 'uturn-left'],
-				[40.7, -74.0, 'turn-left', 'turn-left'],
-				[40.7, -74.0, 'roundabout-left', 'roundabout-left'],
-				[40.7, -74.0, 'fork-left', 'fork-left'],
-				[40.7, -74.0, 'ramp-left', 'ramp-left'],
-				[40.7, -74.0, 'uturn-right', 'uturn-right'],
-				[40.7, -74.0, 'turn-slight-right', 'turn-slight-right'],
-				[40.7, -74.0, 'turn-right', 'turn-right'],
-				[40.7, -74.0, 'roundabout-right', 'roundabout-right'],
-				[40.7, -74.0, 'ramp-right', 'ramp-right'],
-				[40.7, -74.0, 'fork-right', 'fork-right'],
-				[40.7, -74.0, 'turn-sharp-right', 'turn-sharp-right'],
-				[40.7, -74.0, 'merge', 'merge'],
-				[40.7, -74.0, 'straight', 'straight'],
-				[40.7, -74.0, 'ferry-train', 'ferry-train'],
-				[40.7, -74.0, 'ferry', 'ferry'],
-			],
-		};
-		this.getNextStep(testDirections);
-		// this.getNextStep(this.props);
+		this.getNextStep(this.props);
 	};
 
 	render() {
 		return (
-			<Row style={{ backgroundColor: '#056638', color: 'white' }}>
-				<Col md={2}>
+			<div className='instructional-overlay'>
+				<div className='arrow-wrapper'>
 					<InstructionalArrows maneuver={this.state.maneuver} />
-				</Col>
-				<Col md={8}>
-					<h4 className='align-middle'>
-						<div
-							dangerouslySetInnerHTML={{
-								__html: this.state.currentInstructionMessage,
-							}}
-						/>
-					</h4>
-				</Col>
-			</Row>
+				</div>
+				<div
+					className='instruction-wrapper'
+					dangerouslySetInnerHTML={{
+						__html: this.state.currentInstructionMessage,
+					}}
+				/>
+			</div>
 		);
 	}
 }

--- a/src/components/Map/InstructionalOverlay.jsx
+++ b/src/components/Map/InstructionalOverlay.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ArrowRightAltIcon from '@material-ui/icons/ArrowRightAlt';
+import InstructionalArrows from './InstructionalArrows';
 import { Row, Col } from 'react-bootstrap';
 import './InstructionalOverlay.scss';
 
@@ -9,6 +9,7 @@ export default class InstructionalOverlay extends React.Component {
 		this.state = {
 			currentInstruction: 0,
 			currentInstructionMessage: '',
+			maneuver: '',
 		};
 	}
 
@@ -17,21 +18,45 @@ export default class InstructionalOverlay extends React.Component {
 			this.setState({
 				currentInstructionMessage:
 					steps.instruction[this.state.currentInstruction][2],
+				maneuver: steps.instruction[this.state.currentInstruction][3],
 				currentInstruction: this.state.currentInstruction + 1,
 			});
-			setTimeout(() => this.getNextStep(steps), 5000);
+			setTimeout(() => this.getNextStep(steps), 10000);
 		}
 	};
 
 	componentDidMount = () => {
-		this.getNextStep(this.props);
+		const testDirections = {
+			instruction: [
+				[40.7, -74.0, 'turn-sharp-left', 'turn-sharp-left'],
+				[40.7, -74.0, 'turn-slight-left', 'turn-slight-left'],
+				[40.7, -74.0, 'uturn-left', 'uturn-left'],
+				[40.7, -74.0, 'turn-left', 'turn-left'],
+				[40.7, -74.0, 'roundabout-left', 'roundabout-left'],
+				[40.7, -74.0, 'fork-left', 'fork-left'],
+				[40.7, -74.0, 'ramp-left', 'ramp-left'],
+				[40.7, -74.0, 'uturn-right', 'uturn-right'],
+				[40.7, -74.0, 'turn-slight-right', 'turn-slight-right'],
+				[40.7, -74.0, 'turn-right', 'turn-right'],
+				[40.7, -74.0, 'roundabout-right', 'roundabout-right'],
+				[40.7, -74.0, 'ramp-right', 'ramp-right'],
+				[40.7, -74.0, 'fork-right', 'fork-right'],
+				[40.7, -74.0, 'turn-sharp-right', 'turn-sharp-right'],
+				[40.7, -74.0, 'merge', 'merge'],
+				[40.7, -74.0, 'straight', 'straight'],
+				[40.7, -74.0, 'ferry-train', 'ferry-train'],
+				[40.7, -74.0, 'ferry', 'ferry'],
+			],
+		};
+		this.getNextStep(testDirections);
+		// this.getNextStep(this.props);
 	};
 
 	render() {
 		return (
 			<Row style={{ backgroundColor: '#056638', color: 'white' }}>
 				<Col md={2}>
-					<ArrowRightAltIcon style={{ fontSize: 80 }} />
+					<InstructionalArrows maneuver={this.state.maneuver} />
 				</Col>
 				<Col md={8}>
 					<h1 className='align-middle'>

--- a/src/components/Map/InstructionalOverlay.jsx
+++ b/src/components/Map/InstructionalOverlay.jsx
@@ -9,7 +9,6 @@ export default class InstructionalOverlay extends React.Component {
 		this.state = {
 			currentInstruction: 0,
 			currentInstructionMessage: '',
-			timer: null,
 		};
 	}
 

--- a/src/components/Map/InstructionalOverlay.jsx
+++ b/src/components/Map/InstructionalOverlay.jsx
@@ -59,13 +59,13 @@ export default class InstructionalOverlay extends React.Component {
 					<InstructionalArrows maneuver={this.state.maneuver} />
 				</Col>
 				<Col md={8}>
-					<h1 className='align-middle'>
+					<h4 className='align-middle'>
 						<div
 							dangerouslySetInnerHTML={{
 								__html: this.state.currentInstructionMessage,
 							}}
 						/>
-					</h1>
+					</h4>
 				</Col>
 			</Row>
 		);

--- a/src/components/Map/InstructionalOverlay.jsx
+++ b/src/components/Map/InstructionalOverlay.jsx
@@ -20,7 +20,7 @@ export default class InstructionalOverlay extends React.Component {
 				maneuver: steps.instruction[this.state.currentInstruction][3],
 				currentInstruction: this.state.currentInstruction + 1,
 			});
-			setTimeout(() => this.getNextStep(steps), 10000);
+			setTimeout(() => this.getNextStep(steps), 5000);
 		}
 	};
 

--- a/src/components/Map/InstructionalOverlay.scss
+++ b/src/components/Map/InstructionalOverlay.scss
@@ -1,8 +1,31 @@
 @import '../../utilities/colorPalette.scss';
 @import '../../utilities/mediaQueries.scss';
 
-.align-middle{
-font-family: "Quicksand";
-font-size: 35px;
-line-height: 75px;
+.instructional-overlay {
+	position: absolute;
+	width: 100%;
+	font-family: 'Quicksand';
+	font-size: 30px;
+	background-color: $overlay-green;
+	color: white;
+	min-height: 11vh;
+}
+.instructional-overlay div {
+	margin-top: 10px;
+}
+.arrow-wrapper {
+	width: 10%;
+	float: left;
+}
+.instruction-wrapper {
+	width: 89%;
+	float: left;
+}
+
+/* ---------- Arrow styles ----------- */
+.maneuver {
+	font-size: 70px !important;
+}
+.top-left {
+	transform: rotate(45deg);
 }

--- a/src/components/Map/Map.jsx
+++ b/src/components/Map/Map.jsx
@@ -41,7 +41,6 @@ const Map = compose(
 			if (!this.props.location.trip) {
 				return 0;
 			} else {
-				console.log(this.props.location.trip);
 				const {
 					start_lat,
 					start_long,
@@ -80,10 +79,10 @@ const Map = compose(
 											coords.start_location.lat(),
 											coords.start_location.lng(),
 											coords.instructions,
+											coords.maneuver,
 										];
 									}
 								);
-
 								this.setState({
 									directions: result,
 									stepsToDestination: stepsToDestination,

--- a/src/components/Map/Map.jsx
+++ b/src/components/Map/Map.jsx
@@ -22,7 +22,7 @@ const Map = compose(
 		containerElement: (
 			<div
 				style={{
-					height: `88vh`,
+					height: `89vh`,
 					width: `100%`,
 					position: `absolute`,
 					top: `0`,

--- a/src/components/Map/Map.jsx
+++ b/src/components/Map/Map.jsx
@@ -41,6 +41,7 @@ const Map = compose(
 			if (!this.props.location.trip) {
 				return 0;
 			} else {
+				console.log(this.props.location.trip);
 				const {
 					start_lat,
 					start_long,

--- a/src/components/SummaryCard/SummaryCard.jsx
+++ b/src/components/SummaryCard/SummaryCard.jsx
@@ -9,7 +9,6 @@ const SummaryCard = (props) => {
 	const handleClose = () => setShow(false);
 	const handleShow = () => setShow(true);
 	const { trip, host, members, reststops, icon, isYourTrips, rerender } = props;
-	console.log(props);
 	const text = isYourTrips
 		? `You are going to ${trip.destination}.`
 		: `You are invited to ${trip.destination} by ${trip.hostname}.`;

--- a/src/utilities/colorPalette.scss
+++ b/src/utilities/colorPalette.scss
@@ -4,6 +4,7 @@ $dream-blue: #3d6cb9;
 $dream-blue-fade: #86a3d3;
 $fun-yellow: #ffd31d;
 $trust-green: #1abb9c;
+$overlay-green: #056638;
 
 // traffic lights
 $traffic-green: #7cdd82;


### PR DESCRIPTION
## Description
This PR adds different arrows and symbols to match the maneuvers return by the Google Maps api.

## Testing
- [ ] Run the server, start the app
- [ ] Go to any trip and click on Start Trip
- [ ] See the different arrows as the maneuvers change. 
If you don't see an arrow is because the maneuver is empty, so you should see the gps fixed icon instead.
- [ ] If you want to see all the different maneuvers possible, copy the code from this page https://docs.google.com/document/d/1Zv_VSnvI9inIZoZCAQ1eHLGN59oeSvNvsbCtxP0-Eyo/edit?usp=sharing
and paste inside the Component did Mount function of Instructional Overlay component, and comment out line 28 (the only line inside component did mount)

## How are you feeling?
➡️ ⬅️ 
